### PR TITLE
Update permissions in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,6 @@ jobs:
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
       contents: read
-      metadata: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,6 +24,8 @@ jobs:
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
+      contents: read
+      metadata: read
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).


### PR DESCRIPTION
# 📋 Update permissions in scorecard workflow

## Summary
Github recently tightened it's permission strategy. The Scorecard workflow broke because of it.

## Changes Introduced
Updaten permissions in Scorecard workflow file.

## Motivation and Context
See summary

## Testing
Scorecard action works again.

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] All existing and new tests pass
