### PR TITLE
Restructured info/error messages in config

### DIFF
--- a/notebooks/dev/debugging/config_routing.ipynb
+++ b/notebooks/dev/debugging/config_routing.ipynb
@@ -8,7 +8,13 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from resurfemg.data_connector.config import Config"
+    "import logging\n",
+    "from resurfemg.data_connector.config import Config\n",
+    "\n",
+    "logging.basicConfig(\n",
+    "    level=logging.INFO,\n",
+    "    format=\"%(message)s\"\n",
+    ")"
    ]
   },
   {
@@ -48,6 +54,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ca933411",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config.get_directory('simulated_data')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "0aca0244",
    "metadata": {},
    "outputs": [],
@@ -66,7 +82,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv_win312",
+   "display_name": ".venv_312_vogue (3.12.1)",
    "language": "python",
    "name": "python3"
   },
@@ -80,7 +96,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.6"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/resurfemg/data_connector/config.py
+++ b/resurfemg/data_connector/config.py
@@ -141,12 +141,10 @@ class Config:
         self.default_layout = self.get_default_layout()
         if configure:
             location = self.setup_config(location=location, force=force)
-        _path = self.load(location)
+        _path = self.load(location, verbose=verbose)
         self.parse_paths(_path)
         if configure:
             print(f'Created config. See and edit it at:\n {_path}\n')
-        elif verbose:
-            print(f'Loaded config from:\n {_path}\n')
         if verbose or configure:
             print('The following name-path combinations are configured:')
             self.print_config()
@@ -252,7 +250,7 @@ class Config:
             }
         return default_layout
 
-    def load(self, location):
+    def load(self, location, verbose=False):
         """
         This function loads the configuration file. If no location is specified
         it will try to load the configuration file from the default locations:
@@ -270,16 +268,28 @@ class Config:
         locations = (
             [location] if location is not None else self.default_locations
         )
-
+        _failed_paths = []
         for _path in locations:
             try:
                 with open(_path) as f:
                     self._raw = json.load(f)
+                    if verbose:
+                        msg = f'Loaded config file from:\n{_path}'
+                        logging.info(msg)
                     break
             except Exception as e:
-                logging.info(
-                    'Failed to load config file from %s: %s', _path, e)
+                if isinstance(e, FileNotFoundError):
+                    _failed_paths.append(_path)
+                else:
+                    raise e
         else:
+            msg = (
+                'Config file not found in any of the following locations:\n'
+                + '\n'.join(_failed_paths)
+                + '\n\n'
+                + self.usage()
+            )
+            logging.error(msg)
             raise ValueError('Config file not found.' + self.usage())
         return _path
 


### PR DESCRIPTION
## Summary
Restructure error/info messages thrown by config.load()

## Related Issues
Fix #414 

## Changes Introduced
List the major changes made in this PR:
- When a config file is found, no feedback is given about unsuccessful locations (e.g., WORKDIR/config.json and REPO_ROOT/config.json)
- Warnings are only provided when none of the options provided a valid config file

## Motivation and Context
config.load() returned an INFO message that seemed an error, whereas no real error occurred. With this change, such info will not be returned unless no config file could be identified.

## Testing
Describe how you tested your changes. Include:
- Manual testing steps in config notebook

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] All existing and new tests pass

