### PR TITLE
Replace deprecated release action with GH release action

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           path: dist
-      - uses: marvinpinto/action-automatic-releases@d68defdd11f9dcc7f52f35c1b7c236ee7513bcc1
+      - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           repo_token: "${{ secrets.GITHUBTOKEN }}"
           prerelease: false

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -50,7 +50,7 @@ jobs:
           path: dist
       - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
-          repo_token: "${{ secrets.GITHUBTOKEN }}"
+          token: "${{ secrets.GITHUBTOKEN }}"
           prerelease: false
           files: |
             ./dist/*/linux-64/resurfemg-*.tar.bz2


### PR DESCRIPTION
# 📋 Pull Request Template for ReSurfEMG

## Summary
Replaced MarvinPinto Github release workflow with Github's native workflow.

## Related Issues
N/A

## Changes Introduced
List the major changes made in this PR:
- Changed Github release workflow

## Motivation and Context
The previously used release workflow is deprecated.
See: https://github.com/marvinpinto/action-automatic-releases

I expect Github's own workflow to be a sustainable choice.

## Testing
N/A

## Checklist
- [x] I have read the contributing guidelines
- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix is effective or my feature works
- [x] I have updated the documentation accordingly
- [x] All existing and new tests pass

## Additional Notes
Any other context or information reviewers should know?

