### PR TITLE
Modify release files and GITHUB token in Github release workflow

### DIFF
--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -52,5 +52,5 @@ jobs:
         with:
           prerelease: false
           files: |
-            ./dist/*/resurfemg-*.tar.gz2
+            ./dist/*/resurfemg-*.tar.gz
             ./dist/*/resurfemg-*.whl

--- a/.github/workflows/on-tag.yml
+++ b/.github/workflows/on-tag.yml
@@ -50,10 +50,7 @@ jobs:
           path: dist
       - uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
-          token: "${{ secrets.GITHUBTOKEN }}"
           prerelease: false
           files: |
-            ./dist/*/linux-64/resurfemg-*.tar.bz2
-            ./dist/*/osx-64/resurfemg-*.tar.bz2
-            ./dist/*/win-64/resurfemg-*.tar.bz2
-            ./dist/pypi-build/*.whl
+            ./dist/*/resurfemg-*.tar.gz2
+            ./dist/*/resurfemg-*.whl


### PR DESCRIPTION
Updated the release files format and paths in the GitHub Actions workflow.

# 📋 Pull Request Template for ReSurfEMG

## Summary
Github release failed because of files not found and credential error. This should fix it.

